### PR TITLE
ConfigureAwait(false)

### DIFF
--- a/src/Monobank.Core/Services/ClientService.cs
+++ b/src/Monobank.Core/Services/ClientService.cs
@@ -16,6 +16,7 @@ namespace Monobank.Core.Services
         private const string TokenHeader = "X-Token";
         private const int RequestLimit = 60; // seconds
         private const int MaxStatementRange = 2682000; // 31 day + 1 hour
+
         private readonly HttpClient _httpClient;
         private DateTime _previousRequestTimestamp = DateTime.UtcNow.AddSeconds(-RequestLimit);
 
@@ -28,12 +29,14 @@ namespace Monobank.Core.Services
         public async Task<UserInfo?> GetClientInfoAsync()
         {
             var uri = new Uri(ClientInfoEndpoint, UriKind.Relative);
-            var response = await _httpClient.GetAsync(uri);
-            var responseString = await response.Content.ReadAsStringAsync();
+
+            var response = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
             if (!response.IsSuccessStatusCode)
             {
-                var error = JsonSerializer.Deserialize<Error>(responseString);
-                throw new Exception(error!.Description);
+                var error = JsonSerializer.Deserialize<Error>(responseString)!;
+                throw new Exception(error.Description);
             }
             
             return JsonSerializer.Deserialize<UserInfo>(responseString);
@@ -41,7 +44,10 @@ namespace Monobank.Core.Services
 
         public async Task<ICollection<Statement>> GetStatementsAsync(DateTime from, DateTime to, string account = "0")
         {
-            if (to.ToUnixTime() - from.ToUnixTime() >= MaxStatementRange)
+            var startUnixTime = from.ToUnixTime();
+            var endUnixTime = to.ToUnixTime();
+
+            if (endUnixTime - startUnixTime >= MaxStatementRange)
             {
                 throw new Exception("Time range exceeded. Difference between 'from' and 'to' should be less than 31 day + 1 hour.");
             }
@@ -51,15 +57,19 @@ namespace Monobank.Core.Services
                 throw new Exception($"Request limit exceeded. Only 1 request per {RequestLimit} seconds allowed.");
             }
 
-            var uri = new Uri($"{StatementEndpoint}/{account}/{from.ToUnixTime()}/{to.ToUnixTime()}", UriKind.Relative);
-            var response = await _httpClient.GetAsync(uri);
-            var responseString = await response.Content.ReadAsStringAsync();
+            var uri = new Uri($"{StatementEndpoint}/{account}/{startUnixTime}/{endUnixTime}", UriKind.Relative);
+
+            var response = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
             if (!response.IsSuccessStatusCode)
             {
-                var error = JsonSerializer.Deserialize<Error>(responseString);
-                throw new Exception(error!.Description);
+                var error = JsonSerializer.Deserialize<Error>(responseString)!;
+                throw new Exception(error.Description);
             }
+
             _previousRequestTimestamp = DateTime.UtcNow;
+
             return JsonSerializer.Deserialize<ICollection<Statement>>(responseString) ?? [];
         }
 
@@ -70,7 +80,7 @@ namespace Monobank.Core.Services
             // uri to call
             var uri = new Uri(WebhookEndpoint, UriKind.Relative);
             // set webhook
-            var response = await _httpClient.PostAsync(uri, new StringContent(body));
+            var response = await _httpClient.PostAsync(uri, new StringContent(body)).ConfigureAwait(false);
 
             return response.IsSuccessStatusCode;
         }

--- a/src/Monobank.Core/Services/CurrencyService.cs
+++ b/src/Monobank.Core/Services/CurrencyService.cs
@@ -14,12 +14,14 @@ namespace Monobank.Core.Services
         public async Task<ICollection<CurrencyInfo>> GetCurrencies()
         {
             var uri = new Uri($"{CurrencyEndpoint}", UriKind.Relative);
-            var response = await client.GetAsync(uri);
-            var responseString = await response.Content.ReadAsStringAsync();
+
+            var response = await client.GetAsync(uri).ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
             if (!response.IsSuccessStatusCode)
             {
-                var error = JsonSerializer.Deserialize<Error>(responseString);
-                throw new Exception(error!.Description);
+                var error = JsonSerializer.Deserialize<Error>(responseString)!;
+                throw new Exception(error.Description);
             }
 
             return JsonSerializer.Deserialize<ICollection<CurrencyInfo>>(responseString) ?? [];


### PR DESCRIPTION
Added **.ConfigureAwait(false)** to the **async** method calls, since it is a general purpose library, meaning it can be called from any type of application.
In ASP.NET Core there would be no problem even if a consumer of the library would get results using **.Result**, **.Wait()** or **.GetAwaiter().GetResult()** instead of a proper **await** due to the absence of a synchronization context , but in WPF, for example, there would be a deadlock in case of using any of the aforementioned synchronous calls since DispatcherSynchronizationContext schedules continuations on the UI thread which is being blocked by the same operation trying to run the continuation